### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/compute.rs
+++ b/src/compute.rs
@@ -343,7 +343,10 @@ impl Scheduler {
         // Check if identifier corresponds to an existing and open scheduler.
         let exists_and_open = client.is_open(scheduler.clone()).await?.into_inner().value;
         if !exists_and_open {
-            bail!("Identifier '{}' doesn't correspond to an existing and/or open scheduler.");
+            bail!(
+                "Identifier '{}' doesn't correspond to an existing and/or open scheduler.",
+                scheduler.id,
+            );
         }
 
         let adaptor = client.get_adaptor_name(scheduler.clone()).await?.into_inner().name;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -608,7 +608,10 @@ impl FileSystem {
         // Check if identifier corresponds to an existing and open scheduler.
         let exists_and_open = client.is_open(filesystem.clone()).await?.into_inner().value;
         if !exists_and_open {
-            bail!("Identifier '{}' doesn't correspond to an existing and/or open filesystem.");
+            bail!(
+                "Identifier '{}' doesn't correspond to an existing and/or open filesystem.",
+                filesystem.id,
+            );
         }
 
         let adaptor = client.get_adaptor_name(filesystem.clone()).await?.into_inner().name;


### PR DESCRIPTION
Without this, the error message would literally be "Identifier '{}' doesn't correspond to an existing and/or open scheduler" with curly braces in it instead of the identifier.